### PR TITLE
Update deprecated selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -2,7 +2,7 @@
 @import "ui-mixins";
 
 atom-text-editor[mini],
-atom-text-editor[mini]::shadow {
+atom-text-editor[mini].editor {
     color: @text-color-highlight;
     background-color: @input-background-color;
     border: 1px solid @input-border-color;
@@ -19,7 +19,7 @@ atom-text-editor[mini]::shadow {
 }
 
 atom-text-editor[mini].is-focused,
-atom-text-editor[mini].is-focused::shadow {
+atom-text-editor[mini].is-focused.editor {
     background-color: @input-background-color;
 
     .selection .region {

--- a/styles/styles.less
+++ b/styles/styles.less
@@ -69,7 +69,7 @@ atom-text-editor {
 
     // Minimap styling
     // https://atom.io/packages/minimap
-    &::shadow {
+    &.editor {
         atom-text-editor-minimap {
             /deep/ .minimap-visible-area {
                 background: transparent;


### PR DESCRIPTION
Update deprecated selectors from Atom version 1.13 — Issue #9 

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary.